### PR TITLE
bugfix for some browsers

### DIFF
--- a/js/resize.js
+++ b/js/resize.js
@@ -3,7 +3,7 @@ breakpoint.refreshValue = function () {
   this.value = window.getComputedStyle(
     document.querySelector('body'),
     ':before'
-  ).getPropertyValue('content').replace(/\"/g, '');
+  ).getPropertyValue('content').replace(/\"|\'/g, '');
 };
 
 $(window).resize(function () {


### PR DESCRIPTION
Some browsers use single quotes and some use double. This regex provides a catch for BOTH.
